### PR TITLE
feat: dvd - a devimint server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2673,6 +2673,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
+name = "dvd-client"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "reqwest",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dvd-server"
+version = "0.3.0"
+dependencies = [
+ "anyhow",
+ "axum 0.7.9",
+ "clap",
+ "devi",
+ "devimint",
+ "dvd-client",
+ "fedimint-core",
+ "fedimint-logging",
+ "listenfd",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tower-http 0.5.2",
+ "tracing",
+]
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3122,7 @@ dependencies = [
  "communities",
  "devi",
  "devimint",
+ "dvd-client",
  "either",
  "env",
  "eyeball-im",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,8 @@ members = [
   "crates/device-registration",
   "crates/env",
   "crates/fedimint/devi",
+  "crates/fedimint/dvd-client",
+  "crates/fedimint/dvd-server",
   "crates/fedimint/fedimint-cli",
   "crates/fedimint/fedimintd",
   "crates/modules/fedi-social/client",
@@ -80,6 +82,8 @@ debug-tools = { path = "crates/debug-tools" }
 device-registration = { path = "crates/device-registration" }
 env = { path = "crates/env" }
 devi = { path = "crates/fedimint/devi" }
+dvd-client = { path = "crates/fedimint/dvd-client" }
+dvd-server = { path = "crates/fedimint/dvd-server" }
 fedi-ffi = { path = "bridge/fedi-ffi" }
 fedi-social-client = { path = "crates/modules/fedi-social/client" }
 fedi-social-common = { path = "crates/modules/fedi-social/common" }

--- a/bridge/fedi-ffi/Cargo.toml
+++ b/bridge/fedi-ffi/Cargo.toml
@@ -102,6 +102,7 @@ mockito = "1.4.0"
 clap = { workspace = true }
 federations = { workspace = true, features = ["test-support"] }
 devi = { workspace = true }
+dvd-client = { workspace = true }
 
 # FIXME: just put these above? or dev-dependencies
 [target.'cfg(target_os = "macos")'.dependencies]

--- a/bridge/fedi-ffi/src/rpc/tests/matrix.rs
+++ b/bridge/fedi-ffi/src/rpc/tests/matrix.rs
@@ -2,6 +2,7 @@ use std::pin::pin;
 
 use ::matrix::{RpcMsgLikeKind, SendMessageData};
 use bitcoin::hashes::sha256;
+use dvd_client::DvdClient;
 use eyeball_im::VectorDiff;
 use fedimint_core::BitcoinHash;
 use futures::future::try_join;
@@ -16,8 +17,8 @@ use tracing::warn;
 
 use super::*;
 
-pub async fn test_matrix_login(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td = TestDevice::new();
+pub async fn test_matrix_login(dvd: DvdClient) -> anyhow::Result<()> {
+    let td = TestDevice::new(dvd.clone());
     let bridge = td.bridge_full().await?;
 
     // Wait for matrix to initialize
@@ -57,9 +58,9 @@ fn timeline_as_text(items: &Vector<RpcTimelineItem>) -> Vec<Option<String>> {
     items.iter().map(extract_text_from_item).collect()
 }
 
-pub async fn test_matrix_dms(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+pub async fn test_matrix_dms(dvd: DvdClient) -> anyhow::Result<()> {
+    let td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let m1 = td1.matrix().await?;
     let m2 = td2.matrix().await?;
     let user2 = m2.client.user_id().unwrap();
@@ -146,9 +147,9 @@ pub async fn test_matrix_dms(_dev_fed: DevFed) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn test_matrix_recovery(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let mut td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+pub async fn test_matrix_recovery(dvd: DvdClient) -> anyhow::Result<()> {
+    let mut td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let m1 = td1.matrix().await?;
     let m2 = td2.matrix().await?;
     let user2 = m2.client.user_id().unwrap();
@@ -175,7 +176,7 @@ pub async fn test_matrix_recovery(_dev_fed: DevFed) -> anyhow::Result<()> {
     let mnemonic = getMnemonic(td1.bridge_full().await?.runtime.clone()).await?;
     td1.shutdown().await?;
 
-    let td1_recovered = TestDevice::new();
+    let td1_recovered = TestDevice::new(dvd.clone());
     let bridge = td1_recovered.bridge_maybe_onboarding().await?;
     restoreMnemonic(bridge.try_get()?, mnemonic).await?;
     onboardTransferExistingDeviceRegistration(bridge.try_get()?, 0).await?;
@@ -225,8 +226,8 @@ pub async fn test_matrix_recovery(_dev_fed: DevFed) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn test_matrix_create_room(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td = TestDevice::new();
+pub async fn test_matrix_create_room(dvd: DvdClient) -> anyhow::Result<()> {
+    let td = TestDevice::new(dvd.clone());
     let matrix = td.matrix().await?;
     let mut request = ::matrix::create_room::Request::default();
     let room_name = "my name is one".to_string();
@@ -240,7 +241,7 @@ pub async fn test_matrix_create_room(_dev_fed: DevFed) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn test_send_and_download_attachment(_dev_fed: DevFed) -> anyhow::Result<()> {
+pub async fn test_send_and_download_attachment(dvd: DvdClient) -> anyhow::Result<()> {
     let file_size = std::env::var("MATRIX_TEST_FILE_SIZE_MB")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
@@ -250,8 +251,8 @@ pub async fn test_send_and_download_attachment(_dev_fed: DevFed) -> anyhow::Resu
 
     info!("Testing matrix file upload with file size: {}B", file_size);
 
-    let td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+    let td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let matrix = td1.matrix().await?;
     let matrix2 = td2.matrix().await?;
 

--- a/bridge/fedi-ffi/src/rpc/tests/multispend_tests.rs
+++ b/bridge/fedi-ffi/src/rpc/tests/multispend_tests.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use anyhow::Context;
 use bitcoin::secp256k1;
+use dvd_client::DvdClient;
 use fedimint_core::util::backoff_util::aggressive_backoff;
 use fedimint_core::util::retry;
 use multispend::{
@@ -17,9 +18,9 @@ use super::*;
 const MOCK_FEDERATION_INVITE_CODE: &str = "fed11qgqrgvnhwden5te0v9k8q6rp9ekh2arfdeukuet595cr2ttpd3jhq6rzve6zuer9wchxvetyd938gcewvdhk6tcqqysptkuvknc7erjgf4em3zfh90kffqf9srujn6q53d6r056e4apze5cw27h75";
 const MOCK_FEDERATION_ID: &str = "15db8cb4f1ec8e484d73b889372bec94812580f929e8148b7437d359af422cd3";
 
-pub async fn test_multispend_minimal(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+pub async fn test_multispend_minimal(dvd: DvdClient) -> anyhow::Result<()> {
+    let td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let matrix = td1.matrix().await?;
     let matrix2 = td2.matrix().await?;
     let multispend_matrix = td1.multispend().await?;
@@ -72,9 +73,9 @@ pub async fn test_multispend_minimal(_dev_fed: DevFed) -> anyhow::Result<()> {
     Ok(())
 }
 
-pub async fn test_multispend_group_acceptance(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+pub async fn test_multispend_group_acceptance(dvd: DvdClient) -> anyhow::Result<()> {
+    let td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let matrix1 = td1.matrix().await?;
     let matrix2 = td2.matrix().await?;
     let multispend_matrix1 = td1.multispend().await?;
@@ -206,9 +207,9 @@ pub async fn test_multispend_group_acceptance(_dev_fed: DevFed) -> anyhow::Resul
     Ok(())
 }
 
-pub async fn test_multispend_group_rejection(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td1 = TestDevice::new();
-    let td2 = TestDevice::new();
+pub async fn test_multispend_group_rejection(dvd: DvdClient) -> anyhow::Result<()> {
+    let td1 = TestDevice::new(dvd.clone());
+    let td2 = TestDevice::new(dvd.clone());
     let matrix1 = td1.matrix().await?;
     let matrix2 = td2.matrix().await?;
     let multispend_matrix1 = td1.multispend().await?;

--- a/bridge/fedi-ffi/src/rpc/tests/nostr_tests.rs
+++ b/bridge/fedi-ffi/src/rpc/tests/nostr_tests.rs
@@ -1,12 +1,13 @@
 use std::collections::BTreeMap;
 
+use dvd_client::DvdClient;
 use rpc_types::communities::CommunityInviteV2;
 use runtime::storage::state::CommunityJson;
 
 use super::*;
 
-pub async fn test_nostr_community_workflow(_dev_fed: DevFed) -> anyhow::Result<()> {
-    let td = TestDevice::new();
+pub async fn test_nostr_community_workflow(dvd: DvdClient) -> anyhow::Result<()> {
+    let td = TestDevice::new(dvd.clone());
     let bridge = td.bridge_full().await?;
 
     // No communities initially
@@ -104,7 +105,7 @@ pub async fn test_nostr_community_workflow(_dev_fed: DevFed) -> anyhow::Result<(
     Ok(())
 }
 
-pub async fn test_nostr_community_preview_join_leave(_dev_fed: DevFed) -> anyhow::Result<()> {
+pub async fn test_nostr_community_preview_join_leave(dvd: DvdClient) -> anyhow::Result<()> {
     // Creator creates community
     let community_name = "Nostr Test Community".to_string();
     let community_description = "Initial description".to_string();
@@ -112,7 +113,7 @@ pub async fn test_nostr_community_preview_join_leave(_dev_fed: DevFed) -> anyhow
         BTreeMap::from([("description".to_string(), community_description.clone())]);
 
     let invite_code = {
-        let creator = TestDevice::new();
+        let creator = TestDevice::new(dvd.clone());
         let bridge = creator.bridge_full().await?;
 
         let create_payload = CommunityJson {
@@ -130,7 +131,7 @@ pub async fn test_nostr_community_preview_join_leave(_dev_fed: DevFed) -> anyhow
     };
 
     // Joiner previews, then joins, then leaves
-    let joiner = TestDevice::new();
+    let joiner = TestDevice::new(dvd.clone());
     let bridge = joiner.bridge_full().await?;
 
     let preview = communityPreview(bridge, invite_code.to_string()).await?;

--- a/crates/fedimint/dvd-client/Cargo.toml
+++ b/crates/fedimint/dvd-client/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dvd-client"
+version = "0.3.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/fedimint/dvd-client/src/lib.rs
+++ b/crates/fedimint/dvd-client/src/lib.rs
@@ -1,0 +1,231 @@
+mod types;
+
+use anyhow::{Context, Result};
+pub use types::*;
+
+/// Typed client for the DVD (devimint) server API.
+///
+/// This client provides typed access to devimint operations like generating
+/// ecash, sending bitcoin, creating lightning invoices, etc.
+#[derive(Clone)]
+pub struct DvdClient {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl DvdClient {
+    /// Create a new client pointing to the given server URL.
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            base_url: base_url.into(),
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Create a client from the DVD_SERVER_URL environment variable.
+    pub fn from_env() -> Result<Self> {
+        let url = std::env::var("DVD_SERVER_URL")
+            .context("DVD_SERVER_URL environment variable not set")?;
+        Ok(Self::new(url))
+    }
+
+    /// Get the federation invite code.
+    pub async fn invite_code(&self) -> Result<String> {
+        let resp: InviteCodeResponse = self
+            .client
+            .get(format!("{}/invite_code", self.base_url))
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.invite_code)
+    }
+
+    /// Generate ecash notes of the given amount.
+    pub async fn generate_ecash(&self, amount_msats: u64) -> Result<String> {
+        let resp: GenerateEcashResponse = self
+            .client
+            .post(format!("{}/ecash/generate", self.base_url))
+            .json(&GenerateEcashRequest { amount_msats })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.ecash)
+    }
+
+    /// Receive/reissue ecash notes.
+    pub async fn receive_ecash(&self, ecash: String) -> Result<()> {
+        self.client
+            .post(format!("{}/ecash/receive", self.base_url))
+            .json(&ReceiveEcashRequest { ecash })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?;
+        Ok(())
+    }
+
+    /// Send bitcoin to an address and mine blocks.
+    pub async fn send_bitcoin(&self, address: &str, amount_sats: u64) -> Result<String> {
+        let resp: SendBitcoinResponse = self
+            .client
+            .post(format!("{}/bitcoin/send", self.base_url))
+            .json(&SendBitcoinRequest {
+                address: address.to_string(),
+                amount_sats,
+            })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.txid)
+    }
+
+    /// Mine the specified number of blocks.
+    pub async fn mine_blocks(&self, count: u64) -> Result<()> {
+        self.client
+            .post(format!("{}/bitcoin/mine", self.base_url))
+            .json(&MineBlocksRequest { count })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?;
+        Ok(())
+    }
+
+    /// Get a new bitcoin address.
+    pub async fn bitcoin_address(&self) -> Result<String> {
+        let resp: BitcoinAddressResponse = self
+            .client
+            .get(format!("{}/bitcoin/address", self.base_url))
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.address)
+    }
+
+    /// Create an LND invoice.
+    pub async fn create_lnd_invoice(&self, amount_msats: u64) -> Result<(String, Vec<u8>)> {
+        let resp: LndInvoiceResponse = self
+            .client
+            .post(format!("{}/lightning/invoice", self.base_url))
+            .json(&CreateInvoiceRequest { amount_msats })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok((resp.invoice, resp.payment_hash))
+    }
+
+    /// Pay an LND invoice.
+    pub async fn pay_lnd_invoice(&self, invoice: &str) -> Result<()> {
+        self.client
+            .post(format!("{}/lightning/pay", self.base_url))
+            .json(&PayInvoiceRequest {
+                invoice: invoice.to_string(),
+            })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?;
+        Ok(())
+    }
+
+    /// Wait for an LND invoice to be paid.
+    pub async fn wait_lnd_invoice(&self, payment_hash: &[u8]) -> Result<()> {
+        self.client
+            .post(format!("{}/lightning/wait", self.base_url))
+            .json(&WaitInvoiceRequest {
+                payment_hash: payment_hash.to_vec(),
+            })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?;
+        Ok(())
+    }
+
+    /// Get the LND node pubkey.
+    pub async fn lnd_pubkey(&self) -> Result<String> {
+        let resp: LndPubkeyResponse = self
+            .client
+            .get(format!("{}/lightning/pubkey", self.base_url))
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.pubkey)
+    }
+
+    /// Create an invoice via the LDK gateway.
+    pub async fn create_gateway_invoice(&self, amount_msats: u64) -> Result<(String, Vec<u8>)> {
+        let resp: GatewayInvoiceResponse = self
+            .client
+            .post(format!("{}/gateway/invoice", self.base_url))
+            .json(&CreateInvoiceRequest { amount_msats })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok((resp.invoice, resp.payment_hash))
+    }
+
+    /// Wait for a gateway invoice to be paid.
+    pub async fn wait_gateway_invoice(&self, payment_hash: &[u8]) -> Result<()> {
+        self.client
+            .post(format!("{}/gateway/wait", self.base_url))
+            .json(&WaitInvoiceRequest {
+                payment_hash: payment_hash.to_vec(),
+            })
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?;
+        Ok(())
+    }
+
+    /// Get the recurringd API URL.
+    pub async fn recurringd_url(&self) -> Result<String> {
+        let resp: RecurringdUrlResponse = self
+            .client
+            .get(format!("{}/recurringd/url", self.base_url))
+            .send()
+            .await?
+            .better_error_for_status()
+            .await?
+            .json()
+            .await?;
+        Ok(resp.url)
+    }
+}
+
+trait ResponseExt: Sized {
+    async fn better_error_for_status(self) -> anyhow::Result<Self>;
+}
+
+impl ResponseExt for reqwest::Response {
+    async fn better_error_for_status(self) -> anyhow::Result<Self> {
+        let status = self.status();
+        if status.is_client_error() || status.is_server_error() {
+            anyhow::bail!("Status {status}: {body}", body = self.text().await?)
+        } else {
+            Ok(self)
+        }
+    }
+}

--- a/crates/fedimint/dvd-client/src/types.rs
+++ b/crates/fedimint/dvd-client/src/types.rs
@@ -1,0 +1,84 @@
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InviteCodeResponse {
+    pub invite_code: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateEcashRequest {
+    pub amount_msats: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GenerateEcashResponse {
+    pub ecash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ReceiveEcashRequest {
+    pub ecash: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendBitcoinRequest {
+    pub address: String,
+    pub amount_sats: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SendBitcoinResponse {
+    pub txid: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MineBlocksRequest {
+    pub count: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BitcoinAddressResponse {
+    pub address: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateInvoiceRequest {
+    pub amount_msats: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LndInvoiceResponse {
+    pub invoice: String,
+    pub payment_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PayInvoiceRequest {
+    pub invoice: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WaitInvoiceRequest {
+    pub payment_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LndPubkeyResponse {
+    pub pubkey: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GatewayInvoiceResponse {
+    pub invoice: String,
+    pub payment_hash: Vec<u8>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecurringdUrlResponse {
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ErrorResponse {
+    pub error: String,
+}

--- a/crates/fedimint/dvd-server/Cargo.toml
+++ b/crates/fedimint/dvd-server/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "dvd-server"
+version = "0.3.0"
+edition = "2024"
+
+[dependencies]
+anyhow = { workspace = true }
+axum = { version = "0.7", features = ["ws"] }
+clap = { workspace = true }
+devi = { workspace = true }
+devimint = { workspace = true }
+dvd-client = { workspace = true }
+fedimint-core = { workspace = true }
+fedimint-logging = { workspace = true }
+listenfd = "1.0"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true, features = ["full"] }
+tower-http = { version = "0.5", features = ["cors"] }
+tracing = { workspace = true }

--- a/crates/fedimint/dvd-server/src/main.rs
+++ b/crates/fedimint/dvd-server/src/main.rs
@@ -1,0 +1,268 @@
+use std::net::Ipv4Addr;
+use std::sync::Arc;
+
+use anyhow::Result;
+use axum::extract::State;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use clap::Parser;
+use devi::DevFed;
+use devimint::cmd;
+use dvd_client::*;
+use fedimint_core::BitcoinHash;
+use fedimint_logging::TracingSetup;
+use listenfd::ListenFd;
+use tokio::sync::OnceCell;
+use tower_http::cors::{Any, CorsLayer};
+use tracing::info;
+
+#[derive(Clone)]
+struct AppState {
+    dev_fed: Arc<DevFed>,
+}
+
+#[derive(Parser)]
+struct Cli {
+    /// Port to listen on (default: 0 for random)
+    #[arg(short, long, default_value = "0")]
+    port: u16,
+
+    /// Run a command after the server is ready
+    #[arg(trailing_var_arg = true)]
+    run_after_ready: Option<Vec<std::ffi::OsString>>,
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    TracingSetup::default().init()?;
+
+    let cli = Cli::parse();
+
+    info!("Starting devimint federation...");
+    let dev_fed = DevFed::new_with_setup(4).await?;
+    info!("Federation invite code: {}", dev_fed.fed.invite_code()?);
+
+    let state = AppState {
+        dev_fed: Arc::new(dev_fed),
+    };
+
+    let cors = CorsLayer::new()
+        .allow_origin(Any)
+        .allow_methods(Any)
+        .allow_headers(Any);
+
+    let app = Router::new()
+        .route("/invite_code", get(handle_invite_code))
+        .route("/ecash/generate", post(handle_generate_ecash))
+        .route("/ecash/receive", post(handle_receive_ecash))
+        .route("/bitcoin/send", post(handle_send_bitcoin))
+        .route("/bitcoin/mine", post(handle_mine_blocks))
+        .route("/bitcoin/address", get(handle_bitcoin_address))
+        .route("/lightning/invoice", post(handle_lnd_invoice))
+        .route("/lightning/pay", post(handle_lnd_pay))
+        .route("/lightning/wait", post(handle_lnd_wait))
+        .route("/lightning/pubkey", get(handle_lnd_pubkey))
+        .route("/gateway/invoice", post(handle_gateway_invoice))
+        .route("/gateway/wait", post(handle_gateway_wait))
+        .route("/recurringd/url", get(handle_recurringd_url))
+        .layer(cors)
+        .with_state(state);
+
+    let mut listenfd = ListenFd::from_env();
+    let listener = if let Some(listener) = listenfd.take_tcp_listener(0)? {
+        info!("Using listenfd socket");
+        listener.set_nonblocking(true)?;
+        tokio::net::TcpListener::from_std(listener)?
+    } else {
+        tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, cli.port)).await?
+    };
+
+    let port = listener.local_addr()?.port();
+    info!("DVD server listening on http://127.0.0.1:{port}");
+
+    // Set env var for tests to discover the server
+    unsafe {
+        std::env::set_var("DVD_SERVER_URL", format!("http://127.0.0.1:{port}"));
+    }
+
+    let user_cmd_failed = Arc::new(OnceCell::new());
+    let user_cmd_failed2 = user_cmd_failed.clone();
+    let shutdown_signal = async move {
+        if let Some(command) = cli.run_after_ready {
+            if devimint::cli::exec_user_command(command).await.is_err() {
+                user_cmd_failed2.set(true).unwrap();
+            }
+        } else {
+            tokio::signal::ctrl_c()
+                .await
+                .expect("failed to listen to event")
+        }
+    };
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal)
+        .await?;
+
+    if user_cmd_failed.get().is_some_and(|x| *x) {
+        anyhow::bail!("User command failed");
+    }
+
+    Ok(())
+}
+
+struct DvdError(anyhow::Error);
+
+impl<T: Into<anyhow::Error>> From<T> for DvdError {
+    fn from(value: T) -> Self {
+        Self(value.into())
+    }
+}
+
+impl IntoResponse for DvdError {
+    fn into_response(self) -> axum::response::Response {
+        let error_msg = self.0.to_string();
+        (
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ErrorResponse { error: error_msg }),
+        )
+            .into_response()
+    }
+}
+
+async fn handle_invite_code(
+    State(state): State<AppState>,
+) -> Result<Json<InviteCodeResponse>, DvdError> {
+    let invite_code = state.dev_fed.fed.invite_code()?;
+    Ok(Json(InviteCodeResponse { invite_code }))
+}
+
+async fn handle_generate_ecash(
+    State(state): State<AppState>,
+    Json(req): Json<GenerateEcashRequest>,
+) -> Result<Json<GenerateEcashResponse>, DvdError> {
+    let client = state.dev_fed.fed.internal_client().await?;
+    let ecash = cmd!(client, "spend", "--allow-overpay", req.amount_msats)
+        .out_json()
+        .await?["notes"]
+        .as_str()
+        .unwrap()
+        .to_owned();
+    Ok(Json(GenerateEcashResponse { ecash }))
+}
+
+async fn handle_receive_ecash(
+    State(state): State<AppState>,
+    Json(req): Json<ReceiveEcashRequest>,
+) -> Result<Json<()>, DvdError> {
+    let client = state.dev_fed.fed.internal_client().await?;
+    cmd!(client, "reissue", req.ecash).run().await?;
+    Ok(Json(()))
+}
+
+async fn handle_send_bitcoin(
+    State(state): State<AppState>,
+    Json(req): Json<SendBitcoinRequest>,
+) -> Result<Json<SendBitcoinResponse>, DvdError> {
+    let txid = state
+        .dev_fed
+        .bitcoind
+        .send_to(req.address, req.amount_sats)
+        .await?;
+    // Mine blocks to confirm the transaction
+    state.dev_fed.bitcoind.mine_blocks(11).await?;
+    Ok(Json(SendBitcoinResponse {
+        txid: txid.to_string(),
+    }))
+}
+
+async fn handle_mine_blocks(
+    State(state): State<AppState>,
+    Json(req): Json<MineBlocksRequest>,
+) -> Result<Json<()>, DvdError> {
+    state.dev_fed.bitcoind.mine_blocks(req.count).await?;
+    Ok(Json(()))
+}
+
+async fn handle_bitcoin_address(
+    State(state): State<AppState>,
+) -> Result<Json<BitcoinAddressResponse>, DvdError> {
+    let address = state.dev_fed.bitcoind.get_new_address().await?;
+    Ok(Json(BitcoinAddressResponse {
+        address: address.to_string(),
+    }))
+}
+
+async fn handle_lnd_invoice(
+    State(state): State<AppState>,
+    Json(req): Json<CreateInvoiceRequest>,
+) -> Result<Json<LndInvoiceResponse>, DvdError> {
+    let (invoice, payment_hash) = state.dev_fed.lnd.invoice(req.amount_msats).await?;
+    Ok(Json(LndInvoiceResponse {
+        invoice,
+        payment_hash,
+    }))
+}
+
+async fn handle_lnd_pay(
+    State(state): State<AppState>,
+    Json(req): Json<PayInvoiceRequest>,
+) -> Result<Json<()>, DvdError> {
+    state.dev_fed.lnd.pay_bolt11_invoice(req.invoice).await?;
+    Ok(Json(()))
+}
+
+async fn handle_lnd_wait(
+    State(state): State<AppState>,
+    Json(req): Json<WaitInvoiceRequest>,
+) -> Result<Json<()>, DvdError> {
+    state
+        .dev_fed
+        .lnd
+        .wait_bolt11_invoice(req.payment_hash)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn handle_lnd_pubkey(
+    State(state): State<AppState>,
+) -> Result<Json<LndPubkeyResponse>, DvdError> {
+    let pubkey = state.dev_fed.lnd.pub_key().await?;
+    Ok(Json(LndPubkeyResponse { pubkey }))
+}
+
+async fn handle_gateway_invoice(
+    State(state): State<AppState>,
+    Json(req): Json<CreateInvoiceRequest>,
+) -> Result<Json<GatewayInvoiceResponse>, DvdError> {
+    let invoice = state
+        .dev_fed
+        .gw_ldk
+        .create_invoice(req.amount_msats)
+        .await?;
+    let payment_hash = invoice.payment_hash().to_byte_array().to_vec();
+    Ok(Json(GatewayInvoiceResponse {
+        invoice: invoice.to_string(),
+        payment_hash,
+    }))
+}
+
+async fn handle_gateway_wait(
+    State(state): State<AppState>,
+    Json(req): Json<WaitInvoiceRequest>,
+) -> Result<Json<()>, DvdError> {
+    state
+        .dev_fed
+        .gw_ldk
+        .wait_bolt11_invoice(req.payment_hash)
+        .await?;
+    Ok(Json(()))
+}
+
+async fn handle_recurringd_url(
+    State(state): State<AppState>,
+) -> Result<Json<RecurringdUrlResponse>, DvdError> {
+    Ok(Json(RecurringdUrlResponse {
+        url: state.dev_fed.recurringd.api_url.to_string(),
+    }))
+}

--- a/scripts/test-bridge.sh
+++ b/scripts/test-bridge.sh
@@ -29,5 +29,6 @@ export FM_ADMIN_PASSWORD=p
 echo "## Ensuring everything built"
 cargo build --profile "${CARGO_PROFILE}" --all-targets
 echo "## Running v2 bridge tests"
-cargo nextest run -v --locked --cargo-profile "${CARGO_PROFILE}" -E 'package(fedi-ffi)' "$@"
+"${CARGO_BIN_DIR}/dvd-server" \
+	cargo nextest run -v --locked --cargo-profile "${CARGO_PROFILE}" -E 'package(fedi-ffi)' "$@"
 echo "## Tests Passed"


### PR DESCRIPTION
make devimint process controllable as http server.

as a result the tests now can be real tests - they don't share any state.

makes it easier to debug because there is less happening in same process as the test.

Also helps to port wasm because the test can now be compiled to wasm (no devimint/process management)

todo: revive the offline test which needs a dedicated federation - still figuring out best way to run it.
