### PR TITLE
feat(native): update send button label to Send Bitcoin

### DIFF
--- a/ui/common/localization/en/common.json
+++ b/ui/common/localization/en/common.json
@@ -138,7 +138,7 @@
         "searching": "Searching",
         "seen": "Seen",
         "select": "Select",
-        "send": "Send",
+        "send": "Send Bitcoin",
         "sent": "Sent",
         "share": "Share",
         "skip": "Skip",


### PR DESCRIPTION
## Description
- Updated the `words.send` localization key in `ui/common/localization/en/common.json` from "Send" to "Send Bitcoin" for clarity on the Wallet screen send button
## Screenshots/Videos
N/A

## Testing
- [ ] Build the app and confirm the Send button on the Wallet screen displays "Send Bitcoin"
- [ ] - [ ] Confirm no other send-related strings were unintentionally changed
## Impact on native/web parity
No functional change — localization string only