### PR TITLE
feat(native): Merchant Point-of-Sale mode + customer self-order

### DIFF
--- a/ui/common/localization/en/common.json
+++ b/ui/common/localization/en/common.json
@@ -1561,10 +1561,24 @@
             "wallet-provider-guidance": "This is the wallet service securing your wallet and keeping your funds safe."
         },
         "merchant": {
+            "add-product": "Add product",
             "charge": "Charge",
+            "clear": "Clear",
+            "copy-link": "Copy link",
+            "custom-amount": "Enter custom amount",
+            "edit-catalog": "Edit Catalog",
+            "invalid-catalog": "This catalog could not be read.",
+            "item-name": "Item name",
             "merchant-mode": "Merchant Mode",
             "new-sale": "New Sale",
+            "no-products": "No products yet. Add your first item.",
+            "payment-sent": "Payment sent",
+            "payment-unavailable": "This merchant can't accept scan-to-pay yet.",
             "sale-received": "Sale received",
+            "scan-to-order": "Customers scan this to view your menu and pay",
+            "select-products": "Select products",
+            "share-catalog": "Share Catalog",
+            "tap-to-add": "Tap items to add to the sale",
             "waiting-for-payment": "Waiting for Payment"
         }
     }

--- a/ui/common/localization/en/common.json
+++ b/ui/common/localization/en/common.json
@@ -1559,6 +1559,13 @@
             "show-fiat-txn-amounts": "Show Fiat Transaction Amounts",
             "show-fiat-txn-amounts-info": "Transaction amounts will be displayed in the selected fiat currency",
             "wallet-provider-guidance": "This is the wallet service securing your wallet and keeping your funds safe."
+        },
+        "merchant": {
+            "charge": "Charge",
+            "merchant-mode": "Merchant Mode",
+            "new-sale": "New Sale",
+            "sale-received": "Sale received",
+            "waiting-for-payment": "Waiting for Payment"
         }
     }
 }

--- a/ui/native/screens/MainNavigator.tsx
+++ b/ui/native/screens/MainNavigator.tsx
@@ -122,6 +122,9 @@ import Initializing from './Initializing'
 import JoinFederation from './JoinFederation'
 import LanguageSettings from './LanguageSettings'
 import LightningRequestQr from './LightningRequestQr'
+import MerchantAmount from './MerchantAmount'
+import MerchantQr from './MerchantQr'
+import MerchantSuccess from './MerchantSuccess'
 import LocateSocialRecovery from './LocateSocialRecovery'
 import LockScreen from './LockScreen'
 import LockedDevice from './LockedDevice'
@@ -861,6 +864,35 @@ export const MainNavigator = () => {
                             <Stack.Screen
                                 name="ReceiveSuccess"
                                 component={ReceiveSuccess}
+                                options={{ headerShown: false }}
+                            />
+                            <Stack.Screen
+                                name="MerchantAmount"
+                                component={MerchantAmount}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.merchant-mode')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
+                                name="MerchantQr"
+                                component={MerchantQr}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.waiting-for-payment')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
+                                name="MerchantSuccess"
+                                component={MerchantSuccess}
                                 options={{ headerShown: false }}
                             />
                             {/* Transaction history */}

--- a/ui/native/screens/MainNavigator.tsx
+++ b/ui/native/screens/MainNavigator.tsx
@@ -123,6 +123,10 @@ import JoinFederation from './JoinFederation'
 import LanguageSettings from './LanguageSettings'
 import LightningRequestQr from './LightningRequestQr'
 import MerchantAmount from './MerchantAmount'
+import MerchantCatalogEdit from './MerchantCatalogEdit'
+import MerchantCatalogOrder from './MerchantCatalogOrder'
+import MerchantCatalogShare from './MerchantCatalogShare'
+import MerchantProducts from './MerchantProducts'
 import MerchantQr from './MerchantQr'
 import MerchantSuccess from './MerchantSuccess'
 import LocateSocialRecovery from './LocateSocialRecovery'
@@ -867,13 +871,61 @@ export const MainNavigator = () => {
                                 options={{ headerShown: false }}
                             />
                             <Stack.Screen
+                                name="MerchantProducts"
+                                component={MerchantProducts}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.merchant-mode')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
+                                name="MerchantCatalogEdit"
+                                component={MerchantCatalogEdit}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.edit-catalog')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
+                                name="MerchantCatalogShare"
+                                component={MerchantCatalogShare}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.share-catalog')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
+                                name="MerchantCatalogOrder"
+                                component={MerchantCatalogOrder}
+                                options={() => ({
+                                    header: () => (
+                                        <CenteredHeader
+                                            backButton
+                                            title={t('feature.merchant.merchant-mode')}
+                                        />
+                                    ),
+                                })}
+                            />
+                            <Stack.Screen
                                 name="MerchantAmount"
                                 component={MerchantAmount}
                                 options={() => ({
                                     header: () => (
                                         <CenteredHeader
                                             backButton
-                                            title={t('feature.merchant.merchant-mode')}
+                                            title={t('feature.merchant.custom-amount')}
                                         />
                                     ),
                                 })}

--- a/ui/native/screens/MerchantAmount.tsx
+++ b/ui/native/screens/MerchantAmount.tsx
@@ -1,0 +1,141 @@
+import { useNavigation } from '@react-navigation/native'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Theme, useTheme } from '@rneui/themed'
+import React, { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Keyboard, StyleSheet } from 'react-native'
+import { ScrollView } from 'react-native-gesture-handler'
+
+import { useRequestForm } from '@fedi/common/hooks/amount'
+import { useMakeLightningRequest } from '@fedi/common/hooks/receive'
+import { useToast } from '@fedi/common/hooks/toast'
+import { Sats } from '@fedi/common/types'
+import amountUtils from '@fedi/common/utils/AmountUtils'
+
+import PaymentType from '../components/feature/send/PaymentType'
+import { AmountScreen } from '../components/ui/AmountScreen'
+import { useSyncCurrencyRatesOnFocus } from '../utils/hooks/currency'
+import { useRecheckInternet } from '../utils/hooks/environment'
+import type { NavigationHook, RootStackParamList } from '../types/navigation'
+
+export type Props = NativeStackScreenProps<RootStackParamList, 'MerchantAmount'>
+
+const MerchantAmount: React.FC<Props> = ({ route }) => {
+    const [submitAttempts, setSubmitAttempts] = useState(0)
+    const { federationId } = route.params ?? {}
+
+    const recheckConnection = useRecheckInternet()
+    const navigation = useNavigation<NavigationHook>()
+    const toast = useToast()
+    const { theme } = useTheme()
+    const { t } = useTranslation()
+
+    const {
+        inputAmount: amount,
+        setInputAmount: setAmount,
+        exactAmount,
+        memo,
+        setMemo,
+        minimumAmount,
+        maximumAmount,
+    } = useRequestForm({ federationId })
+
+    const { isInvoiceLoading, makeLightningRequest } = useMakeLightningRequest({
+        federationId,
+        onInvoicePaid(tx) {
+            navigation.navigate('MerchantSuccess', {
+                amountSats: amountUtils.msatToSat(tx.amount),
+                federationId,
+            })
+        },
+    })
+
+    useSyncCurrencyRatesOnFocus(federationId)
+
+    const onChangeAmount = (updatedValue: Sats) => {
+        setSubmitAttempts(0)
+        setAmount(updatedValue)
+    }
+
+    const handleSubmit = async () => {
+        setSubmitAttempts(attempts => attempts + 1)
+        if (amount > maximumAmount || amount < minimumAmount) {
+            return
+        }
+
+        const connection = await recheckConnection()
+        if (connection.isOffline) {
+            toast.error(t, t('errors.actions-require-internet'))
+            return
+        }
+
+        Keyboard.dismiss()
+
+        try {
+            const invoice = await makeLightningRequest(amount, memo)
+            if (invoice) {
+                navigation.navigate('MerchantQr', {
+                    invoice,
+                    amountSats: amount,
+                    federationId,
+                })
+            }
+        } catch (e) {
+            toast.error(t, e)
+        }
+    }
+
+    const style = styles(theme)
+
+    return (
+        <ScrollView
+            style={style.container}
+            contentContainerStyle={style.content}>
+            <AmountScreen
+                subHeaderStyle={style.subHeader}
+                federationId={federationId}
+                amount={amount}
+                onChangeAmount={onChangeAmount}
+                minimumAmount={minimumAmount}
+                maximumAmount={maximumAmount}
+                submitAttempts={submitAttempts}
+                isSubmitting={isInvoiceLoading}
+                readOnly={Boolean(exactAmount)}
+                verb={t('feature.merchant.charge')}
+                preHeader={<PaymentType type="lightning" />}
+                buttons={[
+                    {
+                        testID: 'MerchantChargeButton',
+                        title: `${t('feature.merchant.charge')}${
+                            amount ? ` ${amountUtils.formatSats(amount)} ` : ' '
+                        }${t('words.sats').toUpperCase()}`,
+                        onPress: handleSubmit,
+                        disabled: isInvoiceLoading,
+                        loading: isInvoiceLoading,
+                        containerStyle: { width: '100%' },
+                    },
+                ]}
+                isIndependent={false}
+                notes={memo}
+                setNotes={setMemo}
+            />
+        </ScrollView>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            paddingHorizontal: theme.spacing.xl,
+        },
+        content: {
+            flexGrow: 1,
+        },
+        subHeader: {
+            paddingTop: 0,
+            paddingHorizontal: theme.spacing.xl,
+        },
+    })
+
+export default MerchantAmount

--- a/ui/native/screens/MerchantCatalogEdit.tsx
+++ b/ui/native/screens/MerchantCatalogEdit.tsx
@@ -1,0 +1,230 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Button, Text, Theme, useTheme } from '@rneui/themed'
+import React, { useEffect, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Pressable, ScrollView, StyleSheet, TextInput } from 'react-native'
+
+import { useBtcFiatPrice } from '@fedi/common/hooks/amount'
+import { useToast } from '@fedi/common/hooks/toast'
+import { selectSelectedFederation } from '@fedi/common/redux'
+import { UsdCents } from '@fedi/common/types'
+
+import { Column, Row } from '../components/ui/Flex'
+import { SafeAreaContainer } from '../components/ui/SafeArea'
+import SvgImage from '../components/ui/SvgImage'
+import { useAppSelector } from '../state/hooks'
+import {
+    loadMerchantCatalog,
+    makeProductId,
+    MerchantProduct,
+    saveMerchantCatalog,
+} from '../utils/merchantCatalog'
+import type { RootStackParamList } from '../types/navigation'
+
+export type Props = NativeStackScreenProps<
+    RootStackParamList,
+    'MerchantCatalogEdit'
+>
+
+const MerchantCatalogEdit: React.FC<Props> = ({ route }) => {
+    const selectedFederation = useAppSelector(selectSelectedFederation)
+    const federationId = route.params?.federationId || selectedFederation?.id
+
+    const { theme } = useTheme()
+    const { t } = useTranslation()
+    const toast = useToast()
+    const { convertCentsToFormattedFiat } = useBtcFiatPrice(
+        undefined,
+        federationId,
+    )
+
+    const [items, setItems] = useState<MerchantProduct[]>([])
+    const [name, setName] = useState('')
+    const [price, setPrice] = useState('')
+
+    useEffect(() => {
+        let active = true
+        loadMerchantCatalog(federationId).then(loaded => {
+            if (active) setItems(loaded)
+        })
+        return () => {
+            active = false
+        }
+    }, [federationId])
+
+    const persist = (next: MerchantProduct[]) => {
+        setItems(next)
+        saveMerchantCatalog(federationId, next).catch(e => toast.error(t, e))
+    }
+
+    const priceCents = Math.round(parseFloat(price) * 100)
+    const canAdd = name.trim().length > 0 && Number.isFinite(priceCents) && priceCents > 0
+
+    const handleAdd = () => {
+        if (!canAdd) return
+        persist([
+            ...items,
+            {
+                id: makeProductId(),
+                name: name.trim(),
+                priceCents: priceCents as UsdCents,
+            },
+        ])
+        setName('')
+        setPrice('')
+    }
+
+    const handleRemove = (id: string) =>
+        persist(items.filter(item => item.id !== id))
+
+    const style = styles(theme)
+
+    return (
+        <SafeAreaContainer edges="notop" style={style.container}>
+            <ScrollView
+                style={style.list}
+                contentContainerStyle={style.listContent}
+                showsVerticalScrollIndicator={false}
+                keyboardShouldPersistTaps="handled">
+                {items.length === 0 ? (
+                    <Text caption color={theme.colors.grey} style={style.empty}>
+                        {t('feature.merchant.no-products')}
+                    </Text>
+                ) : (
+                    items.map(item => (
+                        <Row
+                            key={item.id}
+                            align="center"
+                            gap="md"
+                            style={style.row}>
+                            <Column gap="xs" grow>
+                                <Text medium>{item.name}</Text>
+                                <Text small color={theme.colors.darkGrey}>
+                                    {convertCentsToFormattedFiat(
+                                        item.priceCents as UsdCents,
+                                    )}
+                                </Text>
+                            </Column>
+                            <Pressable
+                                hitSlop={8}
+                                style={style.deleteButton}
+                                onPress={() => handleRemove(item.id)}>
+                                <SvgImage
+                                    name="Trash"
+                                    size="sm"
+                                    color={theme.colors.red}
+                                />
+                            </Pressable>
+                        </Row>
+                    ))
+                )}
+            </ScrollView>
+
+            <Column gap="md" fullWidth style={style.addSection}>
+                <Text medium>{t('feature.merchant.add-product')}</Text>
+                <TextInput
+                    style={style.input}
+                    value={name}
+                    onChangeText={setName}
+                    placeholder={t('feature.merchant.item-name')}
+                    placeholderTextColor={theme.colors.grey}
+                    maxLength={40}
+                    returnKeyType="next"
+                />
+                <Row align="center" gap="sm" fullWidth style={style.priceWrap}>
+                    <Text medium color={theme.colors.darkGrey}>
+                        $
+                    </Text>
+                    <TextInput
+                        style={style.priceInput}
+                        value={price}
+                        onChangeText={setPrice}
+                        placeholder="0.00"
+                        placeholderTextColor={theme.colors.grey}
+                        keyboardType="decimal-pad"
+                        returnKeyType="done"
+                        onSubmitEditing={handleAdd}
+                    />
+                </Row>
+                <Button
+                    testID="AddProductButton"
+                    title={t('words.add')}
+                    icon={
+                        <SvgImage
+                            name="Plus"
+                            size="xs"
+                            color={theme.colors.secondary}
+                        />
+                    }
+                    onPress={handleAdd}
+                    disabled={!canAdd}
+                    containerStyle={style.fullWidth}
+                />
+            </Column>
+        </SafeAreaContainer>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        list: {
+            flex: 1,
+        },
+        listContent: {
+            paddingVertical: theme.spacing.md,
+            gap: theme.spacing.sm,
+        },
+        empty: {
+            textAlign: 'center',
+            paddingVertical: theme.spacing.xl,
+        },
+        row: {
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            borderRadius: theme.borders.defaultRadius,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        deleteButton: {
+            width: 36,
+            height: 36,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        addSection: {
+            paddingTop: theme.spacing.md,
+            paddingBottom: theme.spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.lightGrey,
+        },
+        input: {
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            borderRadius: theme.borders.defaultRadius,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+            color: theme.colors.primary,
+            fontSize: 16,
+        },
+        priceWrap: {
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            borderRadius: theme.borders.defaultRadius,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        priceInput: {
+            flex: 1,
+            paddingVertical: theme.spacing.md,
+            color: theme.colors.primary,
+            fontSize: 16,
+        },
+        fullWidth: {
+            width: '100%',
+        },
+    })
+
+export default MerchantCatalogEdit

--- a/ui/native/screens/MerchantCatalogOrder.tsx
+++ b/ui/native/screens/MerchantCatalogOrder.tsx
@@ -1,0 +1,359 @@
+import { useNavigation } from '@react-navigation/native'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Button, Text, Theme, useTheme } from '@rneui/themed'
+import React, { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Pressable, ScrollView, StyleSheet } from 'react-native'
+
+import { useBtcFiatPrice } from '@fedi/common/hooks/amount'
+import { useFedimint } from '@fedi/common/hooks/fedimint'
+import { useToast } from '@fedi/common/hooks/toast'
+import {
+    selectIsInternetUnreachable,
+    selectSelectedFederation,
+} from '@fedi/common/redux'
+import { ParserDataType, Sats, UsdCents } from '@fedi/common/types'
+import amountUtils from '@fedi/common/utils/AmountUtils'
+import { lnurlPay } from '@fedi/common/utils/lnurl'
+import { makeLog } from '@fedi/common/utils/log'
+import { parseUserInput } from '@fedi/common/utils/parser'
+
+import { Column, Row } from '../components/ui/Flex'
+import { SafeAreaContainer } from '../components/ui/SafeArea'
+import SvgImage from '../components/ui/SvgImage'
+import { useAppSelector } from '../state/hooks'
+import type { NavigationHook, RootStackParamList } from '../types/navigation'
+
+const log = makeLog('native/screens/MerchantCatalogOrder')
+
+export type Props = NativeStackScreenProps<
+    RootStackParamList,
+    'MerchantCatalogOrder'
+>
+
+// Wire format uses short keys to keep the QR compact (see MerchantCatalogShare).
+type WireItem = { n: string; c: number }
+type OrderItem = { name: string; priceCents: number }
+type CatalogPayload = { v: number; l?: string; i: WireItem[] }
+
+function decodeCatalog(d?: string): CatalogPayload | null {
+    if (!d) return null
+    try {
+        const parsed = JSON.parse(d)
+        if (parsed && Array.isArray(parsed.i)) return parsed as CatalogPayload
+        return null
+    } catch {
+        return null
+    }
+}
+
+const MerchantCatalogOrder: React.FC<Props> = ({ route }) => {
+    const { theme } = useTheme()
+    const { t } = useTranslation()
+    const navigation = useNavigation<NavigationHook>()
+    const toast = useToast()
+    const fedimint = useFedimint()
+
+    const selectedFederation = useAppSelector(selectSelectedFederation)
+    const federationId = selectedFederation?.id
+    const isOffline = useAppSelector(selectIsInternetUnreachable)
+    const { convertCentsToSats, convertCentsToFormattedFiat } = useBtcFiatPrice(
+        undefined,
+        federationId,
+    )
+
+    const payload = useMemo(() => decodeCatalog(route.params?.d), [route.params])
+    const items: OrderItem[] = useMemo(
+        () => (payload?.i ?? []).map(it => ({ name: it.n, priceCents: it.c })),
+        [payload],
+    )
+    const merchantLnurl = payload?.l
+
+    const [cart, setCart] = useState<Record<number, number>>({})
+    const [isPaying, setIsPaying] = useState(false)
+
+    const totalCents = useMemo(
+        () =>
+            items.reduce(
+                (sum, item, idx) => sum + item.priceCents * (cart[idx] ?? 0),
+                0,
+            ) as UsdCents,
+        [cart, items],
+    )
+    const itemCount = useMemo(
+        () => Object.values(cart).reduce((a, b) => a + b, 0),
+        [cart],
+    )
+    const totalSats = convertCentsToSats(totalCents)
+
+    const addItem = (idx: number) =>
+        setCart(c => ({ ...c, [idx]: (c[idx] ?? 0) + 1 }))
+
+    const removeItem = (idx: number) =>
+        setCart(c => {
+            const nextQty = (c[idx] ?? 0) - 1
+            const updated = { ...c }
+            if (nextQty <= 0) {
+                delete updated[idx]
+            } else {
+                updated[idx] = nextQty
+            }
+            return updated
+        })
+
+    const handlePay = useCallback(async () => {
+        if (itemCount === 0 || totalSats <= 0 || !federationId) return
+        if (!merchantLnurl) {
+            toast.error(t, t('feature.merchant.payment-unavailable'))
+            return
+        }
+        setIsPaying(true)
+        try {
+            const parsed = await parseUserInput(
+                merchantLnurl,
+                fedimint,
+                t,
+                federationId,
+                isOffline,
+            )
+            if (parsed.type !== ParserDataType.LnurlPay) {
+                throw new Error(t('feature.merchant.payment-unavailable'))
+            }
+            const notes = items
+                .filter((_, idx) => cart[idx])
+                .map((item, idx) => `${cart[idx]}× ${item.name}`)
+                .join(', ')
+            const result = await lnurlPay(
+                fedimint,
+                federationId,
+                parsed.data,
+                amountUtils.satToMsat(totalSats as Sats),
+                notes,
+            )
+            result.match(
+                () => {
+                    toast.show({
+                        content: t('feature.merchant.payment-sent'),
+                        status: 'success',
+                    })
+                    setCart({})
+                    navigation.goBack()
+                },
+                err => {
+                    log.error('Merchant catalog lnurl pay failed', err)
+                    toast.error(t, err)
+                },
+            )
+        } catch (e) {
+            toast.error(t, e)
+        } finally {
+            setIsPaying(false)
+        }
+    }, [
+        itemCount,
+        totalSats,
+        federationId,
+        merchantLnurl,
+        fedimint,
+        t,
+        isOffline,
+        items,
+        cart,
+        toast,
+        navigation,
+    ])
+
+    const style = styles(theme)
+
+    if (!payload) {
+        return (
+            <SafeAreaContainer edges="notop" style={style.center}>
+                <Text caption center color={theme.colors.grey}>
+                    {t('feature.merchant.invalid-catalog')}
+                </Text>
+            </SafeAreaContainer>
+        )
+    }
+
+    return (
+        <SafeAreaContainer edges="notop" style={style.container}>
+            <ScrollView
+                style={style.list}
+                contentContainerStyle={style.listContent}
+                showsVerticalScrollIndicator={false}>
+                <Text caption color={theme.colors.grey} style={style.hint}>
+                    {t('feature.merchant.tap-to-add')}
+                </Text>
+                {items.map((item, idx) => {
+                    const qty = cart[idx] ?? 0
+                    const selected = qty > 0
+                    return (
+                        <Row
+                            key={`${item.name}-${idx}`}
+                            align="center"
+                            gap="md"
+                            style={[style.row, selected && style.rowSelected]}>
+                            <Pressable
+                                style={style.rowMain}
+                                onPress={() => addItem(idx)}>
+                                <Column gap="xs">
+                                    <Text medium>{item.name}</Text>
+                                    <Text small color={theme.colors.darkGrey}>
+                                        {convertCentsToFormattedFiat(
+                                            item.priceCents as UsdCents,
+                                        )}
+                                    </Text>
+                                </Column>
+                            </Pressable>
+                            {selected ? (
+                                <Row align="center" gap="md">
+                                    <Pressable
+                                        hitSlop={8}
+                                        style={style.stepButton}
+                                        onPress={() => removeItem(idx)}>
+                                        <SvgImage
+                                            name="Minus"
+                                            size="xs"
+                                            color={theme.colors.primary}
+                                        />
+                                    </Pressable>
+                                    <Text bold style={style.qty}>
+                                        {qty}
+                                    </Text>
+                                    <Pressable
+                                        hitSlop={8}
+                                        style={style.stepButton}
+                                        onPress={() => addItem(idx)}>
+                                        <SvgImage
+                                            name="Plus"
+                                            size="xs"
+                                            color={theme.colors.primary}
+                                        />
+                                    </Pressable>
+                                </Row>
+                            ) : (
+                                <Pressable
+                                    hitSlop={8}
+                                    style={style.addButton}
+                                    onPress={() => addItem(idx)}>
+                                    <SvgImage
+                                        name="Plus"
+                                        size="xs"
+                                        color={theme.colors.primary}
+                                    />
+                                </Pressable>
+                            )}
+                        </Row>
+                    )
+                })}
+            </ScrollView>
+
+            <Column gap="md" fullWidth style={style.footer}>
+                <Row align="center" justify="between" fullWidth>
+                    <Row align="center" gap="sm">
+                        <SvgImage
+                            name="Cash"
+                            size="sm"
+                            color={theme.colors.darkGrey}
+                        />
+                        <Text medium color={theme.colors.darkGrey}>
+                            {itemCount}
+                        </Text>
+                    </Row>
+                    <Column align="end" gap="xs">
+                        <Text h2 bold>
+                            {convertCentsToFormattedFiat(totalCents)}
+                        </Text>
+                        <Text small color={theme.colors.grey}>
+                            {`${totalSats} ${t('words.sats').toUpperCase()}`}
+                        </Text>
+                    </Column>
+                </Row>
+                <Button
+                    testID="CatalogPayButton"
+                    title={
+                        itemCount > 0
+                            ? `${t('words.pay')} ${convertCentsToFormattedFiat(
+                                  totalCents,
+                              )}`
+                            : t('feature.merchant.select-products')
+                    }
+                    onPress={handlePay}
+                    disabled={itemCount === 0 || isPaying}
+                    loading={isPaying}
+                    containerStyle={style.fullWidth}
+                />
+            </Column>
+        </SafeAreaContainer>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        center: {
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: theme.spacing.lg,
+        },
+        list: {
+            flex: 1,
+        },
+        listContent: {
+            paddingVertical: theme.spacing.sm,
+            gap: theme.spacing.sm,
+        },
+        hint: {
+            paddingBottom: theme.spacing.sm,
+        },
+        row: {
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            borderRadius: theme.borders.defaultRadius,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        rowSelected: {
+            borderColor: theme.colors.primary,
+        },
+        rowMain: {
+            flex: 1,
+        },
+        addButton: {
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        stepButton: {
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: theme.colors.primary,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        qty: {
+            minWidth: 20,
+            textAlign: 'center',
+        },
+        footer: {
+            paddingTop: theme.spacing.md,
+            paddingBottom: theme.spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.lightGrey,
+        },
+        fullWidth: {
+            width: '100%',
+        },
+    })
+
+export default MerchantCatalogOrder

--- a/ui/native/screens/MerchantCatalogShare.tsx
+++ b/ui/native/screens/MerchantCatalogShare.tsx
@@ -1,0 +1,136 @@
+import Clipboard from '@react-native-clipboard/clipboard'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Button, Text, Theme, useTheme } from '@rneui/themed'
+import React, { useEffect, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Share, StyleSheet } from 'react-native'
+
+import { useLnurlReceiveCode } from '@fedi/common/hooks/receive'
+import { useToast } from '@fedi/common/hooks/toast'
+import { selectSelectedFederation } from '@fedi/common/redux'
+
+import { Column } from '../components/ui/Flex'
+import QRCode from '../components/ui/QRCode'
+import { SafeAreaContainer } from '../components/ui/SafeArea'
+import { useAppSelector } from '../state/hooks'
+import { loadMerchantCatalog, MerchantProduct } from '../utils/merchantCatalog'
+import type { RootStackParamList } from '../types/navigation'
+
+export type Props = NativeStackScreenProps<
+    RootStackParamList,
+    'MerchantCatalogShare'
+>
+
+/**
+ * Encode the catalog (and the merchant's LNURL, when available) into a Fedi
+ * universal deeplink. Scanning it routes to `MerchantCatalogOrder` via the
+ * standard deeplink → screenMap path. Short keys keep the QR compact.
+ */
+export function buildCatalogUrl(
+    items: MerchantProduct[],
+    lnurl: string | null,
+): string {
+    const payload = {
+        v: 1,
+        ...(lnurl ? { l: lnurl } : {}),
+        i: items.map(p => ({ n: p.name, c: p.priceCents })),
+    }
+    const params = new URLSearchParams({
+        screen: 'merchant-catalog',
+        d: JSON.stringify(payload),
+    })
+    return `https://app.fedi.xyz/link?${params.toString()}`
+}
+
+const MerchantCatalogShare: React.FC<Props> = ({ route }) => {
+    const selectedFederation = useAppSelector(selectSelectedFederation)
+    const federationId = route.params?.federationId || selectedFederation?.id
+
+    const { theme } = useTheme()
+    const { t } = useTranslation()
+    const toast = useToast()
+
+    const { lnurlReceiveCode, supportsLnurl } = useLnurlReceiveCode(
+        federationId || '',
+    )
+
+    const [items, setItems] = useState<MerchantProduct[]>([])
+    useEffect(() => {
+        let active = true
+        loadMerchantCatalog(federationId).then(loaded => {
+            if (active) setItems(loaded)
+        })
+        return () => {
+            active = false
+        }
+    }, [federationId])
+
+    const url = useMemo(
+        () => buildCatalogUrl(items, lnurlReceiveCode),
+        [items, lnurlReceiveCode],
+    )
+
+    const handleCopy = () => {
+        Clipboard.setString(url)
+        toast.show(t('phrases.copied-to-clipboard'))
+    }
+
+    const handleShare = () => {
+        Share.share({ message: url }).catch(e => toast.error(t, e))
+    }
+
+    const style = styles(theme)
+
+    if (items.length === 0) {
+        return (
+            <SafeAreaContainer edges="notop" style={style.center}>
+                <Text caption center color={theme.colors.grey}>
+                    {t('feature.merchant.no-products')}
+                </Text>
+            </SafeAreaContainer>
+        )
+    }
+
+    return (
+        <SafeAreaContainer edges="notop" style={style.container}>
+            <Column align="center" justify="center" gap="lg" grow>
+                <Text caption center color={theme.colors.darkGrey}>
+                    {t('feature.merchant.scan-to-order')}
+                </Text>
+                <QRCode value={url} size={260} />
+                {supportsLnurl === false && (
+                    <Text small center color={theme.colors.red}>
+                        {t('feature.merchant.payment-unavailable')}
+                    </Text>
+                )}
+            </Column>
+            <Column gap="md" fullWidth style={style.footer}>
+                <Button title={t('words.share')} onPress={handleShare} />
+                <Button
+                    type="clear"
+                    title={t('feature.merchant.copy-link')}
+                    onPress={handleCopy}
+                />
+            </Column>
+        </SafeAreaContainer>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        center: {
+            flex: 1,
+            alignItems: 'center',
+            justifyContent: 'center',
+            paddingHorizontal: theme.spacing.lg,
+        },
+        footer: {
+            paddingBottom: theme.spacing.sm,
+        },
+    })
+
+export default MerchantCatalogShare

--- a/ui/native/screens/MerchantProducts.tsx
+++ b/ui/native/screens/MerchantProducts.tsx
@@ -1,0 +1,370 @@
+import { useFocusEffect, useNavigation } from '@react-navigation/native'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Button, Text, Theme, useTheme } from '@rneui/themed'
+import React, { useCallback, useMemo, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Pressable, ScrollView, StyleSheet } from 'react-native'
+
+import { useBtcFiatPrice } from '@fedi/common/hooks/amount'
+import { useMakeLightningRequest } from '@fedi/common/hooks/receive'
+import { useToast } from '@fedi/common/hooks/toast'
+import { selectSelectedFederation } from '@fedi/common/redux'
+import { Sats, UsdCents } from '@fedi/common/types'
+
+import { Column, Row } from '../components/ui/Flex'
+import { SafeAreaContainer } from '../components/ui/SafeArea'
+import SvgImage from '../components/ui/SvgImage'
+import { useAppSelector } from '../state/hooks'
+import { loadMerchantCatalog, MerchantProduct } from '../utils/merchantCatalog'
+import type { NavigationHook, RootStackParamList } from '../types/navigation'
+
+export type Props = NativeStackScreenProps<RootStackParamList, 'MerchantProducts'>
+
+const MerchantProducts: React.FC<Props> = ({ route }) => {
+    const selectedFederation = useAppSelector(selectSelectedFederation)
+    const federationId = route.params?.federationId || selectedFederation?.id
+
+    const { theme } = useTheme()
+    const { t } = useTranslation()
+    const navigation = useNavigation<NavigationHook>()
+    const toast = useToast()
+
+    const { convertCentsToSats, convertCentsToFormattedFiat } = useBtcFiatPrice(
+        undefined,
+        federationId,
+    )
+    const { isInvoiceLoading, makeLightningRequest } = useMakeLightningRequest({
+        federationId,
+    })
+
+    const [products, setProducts] = useState<MerchantProduct[]>([])
+    // Map of product id -> quantity in the cart
+    const [cart, setCart] = useState<Record<string, number>>({})
+
+    // Reload the catalog whenever the screen regains focus so edits made on
+    // the catalog editor are reflected here.
+    useFocusEffect(
+        useCallback(() => {
+            let active = true
+            loadMerchantCatalog(federationId).then(loaded => {
+                if (active) setProducts(loaded)
+            })
+            return () => {
+                active = false
+            }
+        }, [federationId]),
+    )
+
+    const totalCents = useMemo(
+        () =>
+            products.reduce(
+                (sum, p) => sum + p.priceCents * (cart[p.id] ?? 0),
+                0,
+            ) as UsdCents,
+        [cart, products],
+    )
+    const itemCount = useMemo(
+        () => Object.values(cart).reduce((a, b) => a + b, 0),
+        [cart],
+    )
+    const totalSats = convertCentsToSats(totalCents)
+
+    const addItem = (id: string) =>
+        setCart(c => ({ ...c, [id]: (c[id] ?? 0) + 1 }))
+
+    const removeItem = (id: string) =>
+        setCart(c => {
+            const nextQty = (c[id] ?? 0) - 1
+            const updated = { ...c }
+            if (nextQty <= 0) {
+                delete updated[id]
+            } else {
+                updated[id] = nextQty
+            }
+            return updated
+        })
+
+    const clearCart = () => setCart({})
+
+    const handleCheckout = async () => {
+        if (itemCount === 0 || totalSats <= 0) return
+
+        const memo = products
+            .filter(p => cart[p.id])
+            .map(p => `${cart[p.id]}× ${p.name}`)
+            .join(', ')
+
+        try {
+            const invoice = await makeLightningRequest(totalSats as Sats, memo)
+            if (invoice) {
+                navigation.navigate('MerchantQr', {
+                    invoice,
+                    amountSats: totalSats as Sats,
+                    federationId,
+                })
+            }
+        } catch (e) {
+            toast.error(t, e)
+        }
+    }
+
+    const goToEdit = () =>
+        navigation.navigate('MerchantCatalogEdit', { federationId })
+
+    const goToShare = () =>
+        navigation.navigate('MerchantCatalogShare', { federationId })
+
+    const style = styles(theme)
+
+    return (
+        <SafeAreaContainer edges="notop" style={style.container}>
+            <Row align="center" justify="between" fullWidth style={style.topBar}>
+                <Text caption color={theme.colors.grey}>
+                    {t('feature.merchant.tap-to-add')}
+                </Text>
+                <Row align="center" gap="sm">
+                    <Button
+                        type="clear"
+                        title={t('words.share')}
+                        titleStyle={style.linkLabel}
+                        icon={
+                            <SvgImage
+                                name="Scan"
+                                size="xs"
+                                color={theme.colors.darkGrey}
+                            />
+                        }
+                        onPress={goToShare}
+                    />
+                    <Button
+                        type="clear"
+                        title={t('words.edit')}
+                        titleStyle={style.linkLabel}
+                        icon={
+                            <SvgImage
+                                name="Edit"
+                                size="xs"
+                                color={theme.colors.darkGrey}
+                            />
+                        }
+                        onPress={goToEdit}
+                    />
+                </Row>
+            </Row>
+            <ScrollView
+                style={style.list}
+                contentContainerStyle={style.listContent}
+                showsVerticalScrollIndicator={false}>
+                {products.length === 0 ? (
+                    <Column center gap="md" style={style.empty}>
+                        <Text caption color={theme.colors.grey}>
+                            {t('feature.merchant.no-products')}
+                        </Text>
+                        <Button
+                            title={t('feature.merchant.add-product')}
+                            onPress={goToEdit}
+                        />
+                    </Column>
+                ) : (
+                    products.map(product => {
+                        const qty = cart[product.id] ?? 0
+                        const selected = qty > 0
+                        return (
+                            <Row
+                                key={product.id}
+                                align="center"
+                                gap="md"
+                                style={[style.row, selected && style.rowSelected]}>
+                                <Pressable
+                                    style={style.rowMain}
+                                    onPress={() => addItem(product.id)}>
+                                    <Row align="center" gap="md">
+                                        <Column center style={style.avatar}>
+                                            <Text bold color={theme.colors.primary}>
+                                                {product.name
+                                                    .charAt(0)
+                                                    .toUpperCase()}
+                                            </Text>
+                                        </Column>
+                                        <Column gap="xs" grow shrink>
+                                            <Text medium>{product.name}</Text>
+                                            <Text
+                                                small
+                                                color={theme.colors.darkGrey}>
+                                                {convertCentsToFormattedFiat(
+                                                    product.priceCents as UsdCents,
+                                                )}
+                                            </Text>
+                                        </Column>
+                                    </Row>
+                                </Pressable>
+                                {selected ? (
+                                    <Row align="center" gap="md">
+                                        <Pressable
+                                            hitSlop={8}
+                                            style={style.stepButton}
+                                            onPress={() =>
+                                                removeItem(product.id)
+                                            }>
+                                            <SvgImage
+                                                name="Minus"
+                                                size="xs"
+                                                color={theme.colors.primary}
+                                            />
+                                        </Pressable>
+                                        <Text bold style={style.qty}>
+                                            {qty}
+                                        </Text>
+                                        <Pressable
+                                            hitSlop={8}
+                                            style={style.stepButton}
+                                            onPress={() => addItem(product.id)}>
+                                            <SvgImage
+                                                name="Plus"
+                                                size="xs"
+                                                color={theme.colors.primary}
+                                            />
+                                        </Pressable>
+                                    </Row>
+                                ) : (
+                                    <Pressable
+                                        hitSlop={8}
+                                        style={style.addButton}
+                                        onPress={() => addItem(product.id)}>
+                                        <SvgImage
+                                            name="Plus"
+                                            size="xs"
+                                            color={theme.colors.primary}
+                                        />
+                                    </Pressable>
+                                )}
+                            </Row>
+                        )
+                    })
+                )}
+            </ScrollView>
+
+            <Column gap="md" fullWidth style={style.footer}>
+                <Row align="center" justify="between" fullWidth>
+                    <Row align="center" gap="sm">
+                        <SvgImage
+                            name="Cash"
+                            size="sm"
+                            color={theme.colors.darkGrey}
+                        />
+                        <Text medium color={theme.colors.darkGrey}>
+                            {itemCount}
+                        </Text>
+                    </Row>
+                    <Column align="end" gap="xs">
+                        <Text h2 bold>
+                            {convertCentsToFormattedFiat(totalCents)}
+                        </Text>
+                        <Text small color={theme.colors.grey}>
+                            {`${totalSats} ${t('words.sats').toUpperCase()}`}
+                        </Text>
+                    </Column>
+                </Row>
+                <Button
+                    testID="MerchantCheckoutButton"
+                    title={
+                        itemCount > 0
+                            ? `${t('feature.merchant.charge')} ${convertCentsToFormattedFiat(
+                                  totalCents,
+                              )}`
+                            : t('feature.merchant.select-products')
+                    }
+                    onPress={handleCheckout}
+                    disabled={itemCount === 0 || isInvoiceLoading}
+                    loading={isInvoiceLoading}
+                    containerStyle={style.fullWidth}
+                />
+                {itemCount > 0 && (
+                    <Button
+                        type="clear"
+                        title={t('feature.merchant.clear')}
+                        titleStyle={style.linkLabel}
+                        onPress={clearCart}
+                    />
+                )}
+            </Column>
+        </SafeAreaContainer>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        topBar: {
+            paddingTop: theme.spacing.sm,
+        },
+        list: {
+            flex: 1,
+        },
+        listContent: {
+            paddingVertical: theme.spacing.sm,
+            gap: theme.spacing.sm,
+        },
+        empty: {
+            paddingVertical: theme.spacing.xl,
+        },
+        row: {
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            borderRadius: theme.borders.defaultRadius,
+            paddingVertical: theme.spacing.md,
+            paddingHorizontal: theme.spacing.lg,
+        },
+        rowSelected: {
+            borderColor: theme.colors.primary,
+        },
+        rowMain: {
+            flex: 1,
+        },
+        avatar: {
+            width: 40,
+            height: 40,
+            borderRadius: 20,
+            backgroundColor: theme.colors.primaryVeryLight,
+        },
+        addButton: {
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: theme.colors.lightGrey,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        stepButton: {
+            width: 36,
+            height: 36,
+            borderRadius: 18,
+            borderWidth: 1,
+            borderColor: theme.colors.primary,
+            alignItems: 'center',
+            justifyContent: 'center',
+        },
+        qty: {
+            minWidth: 20,
+            textAlign: 'center',
+        },
+        footer: {
+            paddingTop: theme.spacing.md,
+            paddingBottom: theme.spacing.sm,
+            borderTopWidth: 1,
+            borderTopColor: theme.colors.lightGrey,
+        },
+        fullWidth: {
+            width: '100%',
+        },
+        linkLabel: {
+            fontSize: 14,
+            color: theme.colors.darkGrey,
+        },
+    })
+
+export default MerchantProducts

--- a/ui/native/screens/MerchantQr.tsx
+++ b/ui/native/screens/MerchantQr.tsx
@@ -1,0 +1,83 @@
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Theme, useTheme } from '@rneui/themed'
+import React, { useEffect } from 'react'
+import { StyleSheet } from 'react-native'
+
+import { useAmountFormatter } from '@fedi/common/hooks/amount'
+import { useFedimint } from '@fedi/common/hooks/fedimint'
+import amountUtils from '@fedi/common/utils/AmountUtils'
+import { coerceTxn } from '@fedi/common/utils/transaction'
+
+import ReceiveQr from '../components/feature/receive/ReceiveQr'
+import PaymentType from '../components/feature/send/PaymentType'
+import SendAmounts from '../components/feature/send/SendAmounts'
+import { Column } from '../components/ui/Flex'
+import { SafeAreaContainer } from '../components/ui/SafeArea'
+import { BitcoinOrLightning, BtcLnUri } from '../types'
+import type { RootStackParamList } from '../types/navigation'
+
+export type Props = NativeStackScreenProps<RootStackParamList, 'MerchantQr'>
+
+const MerchantQr: React.FC<Props> = ({ route, navigation }: Props) => {
+    const { theme } = useTheme()
+    const { invoice, amountSats, federationId } = route.params
+    const fedimint = useFedimint()
+
+    const { makeFormattedAmountsFromMSats } = useAmountFormatter({
+        federationId,
+    })
+    const amountMSats = amountUtils.satToMsat(amountSats)
+    const { formattedPrimaryAmount, formattedSecondaryAmount } =
+        makeFormattedAmountsFromMSats(amountMSats)
+
+    useEffect(() => {
+        if (!federationId) return
+
+        const unsubscribe = fedimint.addListener(
+            'transaction',
+            ({ transaction }) => {
+                const tx = coerceTxn(transaction)
+                if (tx.kind === 'lnReceive' && tx.ln_invoice === invoice) {
+                    navigation.navigate('MerchantSuccess', {
+                        amountSats,
+                        federationId,
+                    })
+                }
+            },
+        )
+        return unsubscribe
+    }, [invoice, amountSats, fedimint, navigation, federationId])
+
+    const uri = new BtcLnUri({
+        type: BitcoinOrLightning.lightning,
+        body: invoice,
+    })
+
+    const style = styles(theme)
+
+    return (
+        <SafeAreaContainer edges="bottom" padding="xl" style={style.container}>
+            <Column align="center" style={style.amounts}>
+                <PaymentType type="lightning" />
+                <SendAmounts
+                    formattedPrimaryAmount={formattedPrimaryAmount}
+                    formattedSecondaryAmount={formattedSecondaryAmount}
+                />
+            </Column>
+            <ReceiveQr uri={uri} />
+        </SafeAreaContainer>
+    )
+}
+
+const styles = (theme: Theme) =>
+    StyleSheet.create({
+        container: {
+            flex: 1,
+            gap: theme.spacing.lg,
+        },
+        amounts: {
+            paddingVertical: theme.spacing.xl,
+        },
+    })
+
+export default MerchantQr

--- a/ui/native/screens/MerchantSuccess.tsx
+++ b/ui/native/screens/MerchantSuccess.tsx
@@ -47,7 +47,7 @@ const MerchantSuccess: React.FC<Props> = ({ route }: Props) => {
                         title={t('feature.merchant.new-sale')}
                         onPress={() =>
                             navigation.dispatch(
-                                reset('MerchantAmount', { federationId }),
+                                reset('MerchantProducts', { federationId }),
                             )
                         }
                     />

--- a/ui/native/screens/MerchantSuccess.tsx
+++ b/ui/native/screens/MerchantSuccess.tsx
@@ -1,0 +1,65 @@
+import { useNavigation } from '@react-navigation/native'
+import type { NativeStackScreenProps } from '@react-navigation/native-stack'
+import { Button, Text } from '@rneui/themed'
+import React from 'react'
+import { useTranslation } from 'react-i18next'
+
+import { useAmountFormatter } from '@fedi/common/hooks/amount'
+import amountUtils from '@fedi/common/utils/AmountUtils'
+
+import { reset, resetToWallets } from '../state/navigation'
+import type { NavigationHook, RootStackParamList } from '../types/navigation'
+import { Column } from '../components/ui/Flex'
+import Success from '../components/ui/Success'
+
+export type Props = NativeStackScreenProps<
+    RootStackParamList,
+    'MerchantSuccess'
+>
+
+const MerchantSuccess: React.FC<Props> = ({ route }: Props) => {
+    const { t } = useTranslation()
+    const { amountSats, federationId } = route.params
+    const navigation = useNavigation<NavigationHook>()
+
+    const { makeFormattedAmountsFromMSats } = useAmountFormatter({
+        federationId,
+    })
+    const amountMSats = amountUtils.satToMsat(amountSats)
+    const { formattedPrimaryAmount } =
+        makeFormattedAmountsFromMSats(amountMSats)
+
+    return (
+        <Success
+            message={
+                <Column align="center" gap="sm">
+                    <Text center h2>
+                        {t('feature.merchant.sale-received')}
+                    </Text>
+                    <Text center h2>
+                        {formattedPrimaryAmount}
+                    </Text>
+                </Column>
+            }
+            button={
+                <Column gap="sm" fullWidth>
+                    <Button
+                        title={t('feature.merchant.new-sale')}
+                        onPress={() =>
+                            navigation.dispatch(
+                                reset('MerchantAmount', { federationId }),
+                            )
+                        }
+                    />
+                    <Button
+                        title={t('words.done')}
+                        type="outline"
+                        onPress={() => navigation.dispatch(resetToWallets())}
+                    />
+                </Column>
+            }
+        />
+    )
+}
+
+export default MerchantSuccess

--- a/ui/native/screens/Wallet.tsx
+++ b/ui/native/screens/Wallet.tsx
@@ -180,7 +180,9 @@ const Wallet: React.FC<Props> = ({ navigation }) => {
                     }
                     containerStyle={{ width: '100%' }}
                     onPress={() =>
-                        navigation.navigate('MerchantAmount', { federationId })
+                        navigation.navigate('MerchantProducts', {
+                            federationId,
+                        })
                     }
                 />
                 {disabledMessage && (

--- a/ui/native/screens/Wallet.tsx
+++ b/ui/native/screens/Wallet.tsx
@@ -169,6 +169,20 @@ const Wallet: React.FC<Props> = ({ navigation }) => {
                         disabled={sendDisabled}
                     />
                 </Row>
+                <Button
+                    title={t('feature.merchant.merchant-mode')}
+                    type="outline"
+                    icon={
+                        <SvgImage
+                            name="Cash"
+                            color={theme.colors.primary}
+                        />
+                    }
+                    containerStyle={{ width: '100%' }}
+                    onPress={() =>
+                        navigation.navigate('MerchantAmount', { federationId })
+                    }
+                />
                 {disabledMessage && (
                     <Text
                         center

--- a/ui/native/types/navigation.ts
+++ b/ui/native/types/navigation.ts
@@ -81,6 +81,16 @@ export type RootStackParamList = {
         federationId?: Federation['id']
         memo?: string
     }
+    MerchantAmount: { federationId?: Federation['id'] }
+    MerchantQr: {
+        invoice: string
+        amountSats: Sats
+        federationId?: Federation['id']
+    }
+    MerchantSuccess: {
+        amountSats: Sats
+        federationId?: Federation['id']
+    }
     BugReportSuccess: undefined
     CameraPermission: { nextScreen: keyof RootStackParamList } | undefined
     ChatImageViewer: { uri: string; downloadable?: boolean }

--- a/ui/native/types/navigation.ts
+++ b/ui/native/types/navigation.ts
@@ -81,6 +81,10 @@ export type RootStackParamList = {
         federationId?: Federation['id']
         memo?: string
     }
+    MerchantProducts: { federationId?: Federation['id'] }
+    MerchantCatalogEdit: { federationId?: Federation['id'] }
+    MerchantCatalogShare: { federationId?: Federation['id'] }
+    MerchantCatalogOrder: { d?: string }
     MerchantAmount: { federationId?: Federation['id'] }
     MerchantQr: {
         invoice: string

--- a/ui/native/utils/linking.ts
+++ b/ui/native/utils/linking.ts
@@ -152,6 +152,17 @@ export const screenMap = {
         return { kind: 'root', screen: 'JoinFederation' }
     },
     'share-logs': () => ({ kind: 'root', screen: 'ShareLogs' }),
+    'merchant-pos': () => ({ kind: 'root', screen: 'MerchantProducts' }),
+    'merchant-catalog': (params: Record<string, string>) => {
+        const d = params?.d
+        if (d)
+            return {
+                kind: 'root',
+                screen: 'MerchantCatalogOrder',
+                params: { d },
+            }
+        return { kind: 'root', screen: 'MerchantCatalogOrder' }
+    },
     'join-then-ecash': (params: Record<string, string>) => {
         const { invite, ecash } = params
         if (!invite || !ecash) return undefined

--- a/ui/native/utils/merchantCatalog.ts
+++ b/ui/native/utils/merchantCatalog.ts
@@ -1,0 +1,85 @@
+import { makeLog } from '@fedi/common/utils/log'
+
+import { storage } from './storage'
+
+const log = makeLog('native/utils/merchantCatalog')
+
+/**
+ * A single item in a merchant's product catalog.
+ *
+ * `priceCents` is stored as canonical USD cents so it can be converted to sats
+ * via the USD-based `convertCentsToSats`, and displayed in the user's selected
+ * currency via `convertCentsToFormattedFiat`.
+ */
+export type MerchantProduct = {
+    id: string
+    name: string
+    priceCents: number
+}
+
+const keyFor = (federationId?: string) =>
+    `merchant:catalog:${federationId ?? 'default'}`
+
+/**
+ * A starter catalog seeded the first time a merchant opens the screen. It is
+ * fully editable — the merchant can rename, reprice, delete, or add items, and
+ * their changes are persisted per-federation.
+ */
+export const DEFAULT_CATALOG: MerchantProduct[] = [
+    { id: 'espresso', name: 'Espresso', priceCents: 250 },
+    { id: 'cappuccino', name: 'Cappuccino', priceCents: 375 },
+    { id: 'croissant', name: 'Croissant', priceCents: 325 },
+    { id: 'sandwich', name: 'Sandwich', priceCents: 850 },
+    { id: 'salad', name: 'Garden Salad', priceCents: 900 },
+    { id: 'cookie', name: 'Cookie', priceCents: 200 },
+    { id: 'juice', name: 'Fresh Juice', priceCents: 450 },
+    { id: 'tea', name: 'Tea', priceCents: 275 },
+    { id: 'cake', name: 'Cake Slice', priceCents: 550 },
+    { id: 'water', name: 'Water', priceCents: 150 },
+]
+
+const isValidProduct = (p: unknown): p is MerchantProduct =>
+    typeof p === 'object' &&
+    p !== null &&
+    typeof (p as MerchantProduct).id === 'string' &&
+    typeof (p as MerchantProduct).name === 'string' &&
+    typeof (p as MerchantProduct).priceCents === 'number'
+
+/**
+ * Load the merchant's saved catalog. On first use (no saved data) the default
+ * starter catalog is returned so the screen is immediately usable.
+ */
+export async function loadMerchantCatalog(
+    federationId?: string,
+): Promise<MerchantProduct[]> {
+    try {
+        const raw = await storage.getItem(keyFor(federationId))
+        if (raw === null) return DEFAULT_CATALOG
+        const parsed = JSON.parse(raw)
+        if (Array.isArray(parsed) && parsed.every(isValidProduct)) {
+            return parsed
+        }
+        return DEFAULT_CATALOG
+    } catch (e) {
+        log.warn('Failed to load merchant catalog, using default', e)
+        return DEFAULT_CATALOG
+    }
+}
+
+/** Persist the merchant's catalog for a federation. */
+export async function saveMerchantCatalog(
+    federationId: string | undefined,
+    items: MerchantProduct[],
+): Promise<void> {
+    try {
+        await storage.setItem(keyFor(federationId), JSON.stringify(items))
+    } catch (e) {
+        log.error('Failed to save merchant catalog', e)
+        throw e
+    }
+}
+
+/** Generate a reasonably-unique id for a newly created product. */
+export function makeProductId(): string {
+    return `p-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 8)}`
+}


### PR DESCRIPTION
## Summary

Adds an in-app **Merchant Point-of-Sale mode** so a community member can accept Bitcoin / Lightning payments directly from their wallet — merchant acceptance being the backbone of a Bitcoin circular economy, with a focus on Global-South / African community use.

Two self-contained flows:

### 1. Quick charge
Enter an amount → mint a BOLT11 Lightning invoice → show a "Waiting for Payment" QR → auto-detect settlement → "Sale received".
`MerchantAmount` → `MerchantQr` → `MerchantSuccess`.

### 2. Editable catalog + customer self-order
- Merchant keeps a per-federation product catalog. Prices are stored canonically as **USD cents** and displayed in the user's selected fiat **and** sats.
- Build a sale by tapping items; running total shown in fiat and sats; **Charge** mints the invoice.
- **Share** publishes the catalog as a `fedi://merchant-catalog?d=…` deeplink QR. A customer scans it, lands on `MerchantCatalogOrder`, selects items, and pays via `lnurlPay`.
- `MerchantProducts` / `MerchantCatalogEdit` / `MerchantCatalogShare` / `MerchantCatalogOrder` + `utils/merchantCatalog.ts`; deeplink routed in `utils/linking.ts` (`merchant-catalog` → `MerchantCatalogOrder`).

## Entry point
A "Merchant Mode" button on the Wallet screen (`Wallet.tsx`), following the Fedi design system (secondary pill button, ink-on-white, 12px cards, dual-currency amounts).

## Testing
Built and driven end-to-end on the Android emulator against a live federation:
- charge → real `lnbc…` invoice QR → settlement → "Sale received"
- Share → catalog QR → customer `merchant-catalog` deeplink → order screen → Pay
Prices convert correctly between USD cents ↔ sats; offline guarded via `selectIsInternetUnreachable`.

## Scope / notes
- Scoped to just the Merchant PoS feature (13 files, +1,615). Dev-only Firebase config and unrelated commits are intentionally excluded.
- `lnurlPay` settlement requires the federation to support LNURL receive; otherwise the UI shows a clear "can't accept scan-to-pay yet" message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
